### PR TITLE
Bump minimum and maximum module version requirements 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
-## UNRELEASED - Release 2.3.0
+## UNRELEASED - Release 3.0.0
 
 - BC: Changed ssh key name from `barman` to `postgres-${fqdn}` in order to support multiple barman servers
 - `archive_command` might use `rsync` or `barman-wal-archive`
 - add --wait to barman backup cronjob
-- Puppet 6 support
-
+- Puppet 6 support and drop Puppet 5 support
+- Drop deprecated Linux distributions
+- Bump minimum and maximum module version requirements
+- Keep only required `facts` in unit tests
+- Unit tests performance improvement by making `puppetversion` fact to run only once
 
 ## 2019-11-18 - Release 2.2.0
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,26 +1,24 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :development, :unit_tests do
-  gem 'rake',                    :require => false
-  gem 'json_pure', '<= 2.0.1',   :require => false if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
-  gem 'rspec-core',              :require => false
-  gem 'rspec-puppet',            :require => false
-  gem 'puppetlabs_spec_helper',  :require => false
-  gem 'puppet-lint',             :require => false
-  gem 'simplecov',               :require => false
-  gem 'puppet_facts',            :require => false
-  gem 'json',                    :require => false
-  gem 'metadata-json-lint',      :require => false
-  gem 'iconv',                   :require => false
-  gem 'rubocop',                 :require => false
-  gem 'rubocop-rspec',           :require => false
-  gem 'rubocop-i18n',            :require => false
-  gem 'parallel_tests',          :require => false
-  gem 'librarian-puppet', '>= 2.0'
+  gem 'iconv',                  :require => false
+  gem 'metadata-json-lint',     :require => false
+  gem 'parallel_tests',         :require => false
+  gem 'puppet_facts',           :require => false
+  gem 'puppet-lint',            :require => false
+  gem 'puppetlabs_spec_helper', :require => false
+  gem 'rake',                   :require => false
+  gem 'rspec-core',             :require => false
+  gem 'rspec-puppet',           :require => false
+  gem 'rubocop-i18n',           :require => false
+  gem 'rubocop-rspec',          :require => false
+  gem 'rubocop',                :require => false
+  gem 'simplecov',              :require => false
+  gem 'librarian-puppet', '>= 3.0'
 end
 
 group :development do
-  gem 'puppet-blacksmith', git: 'https://github.com/deric/puppet-blacksmith'
+  gem 'puppet-blacksmith'
   gem 'pdk', '>= 1.0'
 end
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,21 +1,20 @@
 {
   "name": "deric-barman",
-  "version": "2.3.0-dev",
+  "version": "3.0.0-dev",
   "author": "Tomas Barton",
   "summary": "Barman (Backup and Recovery Manager for PostgreSQL) module",
   "license": "GPL-3.0",
   "source": "git://github.com/deric/puppet-barman.git",
   "project_page": "https://github.com/deric/puppet-barman.git",
   "issues_url": "https://github.com/deric/puppet-barman/issues",
-  "description": "Automates Barman installation and server setup",
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.6.0 <7.0.0"
+      "version_requirement": ">= 4.13.1 < 8.0.0"
     },
     {
       "name": "puppetlabs/postgresql",
-      "version_requirement": ">=5.0.0 <7.0.0"
+      "version_requirement": ">= 6.10.2 < 8.0.0"
     },
     { "name": "puppetlabs-sshkeys_core",
       "version_requirement": "> 1.0.0"
@@ -28,8 +27,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "6",
-        "7",
         "8",
         "9",
         "10"
@@ -38,32 +35,30 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "10.04",
-        "12.04",
-        "14.04",
         "16.04",
-        "18.04"
+        "18.04",
+        "20.04"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
-        "7"
+        "7",
+        "8"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.0.0 < 7.0.0"
+      "version_requirement": ">= 6.1.0 < 8.0.0"
     }
   ]
 }

--- a/spec/classes/barman_spec.rb
+++ b/spec/classes/barman_spec.rb
@@ -2,16 +2,19 @@
 
 require 'spec_helper'
 
+$PUPPET_VERSION = `puppet --version`
+
 describe 'barman' do
   let(:facts) do
     {
-      os: { family: 'Debian', name: 'Debian', release: { major: '9', full: '9.11' } },
-      puppetversion: `puppet --version`,
-      osfamily: 'Debian',
-      operatingsystem: 'Debian',
-      operatingsystemrelease: '6.0',
-      lsbdistid: 'Debian',
-      lsbdistcodename: 'stretch',
+      os: {
+        family: 'Debian',
+        name: 'Debian',
+        distro: { codename: 'stretch'},
+        release: { major: '9', full: '9.11' }
+      },
+
+      puppetversion: $PUPPET_VERSION,
       ipaddress: '10.0.0.1',
     }
   end


### PR DESCRIPTION
This PR allows to use the module with newer versions of module dependencies. 
All the tests are passes as intended. 