### PR TITLE
Location of barman.conf is configurable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -227,6 +227,7 @@ class barman (
   $user                          = $::barman::settings::user,
   $group                         = $::barman::settings::group,
   $ensure                        = 'present',
+  $conf_file_path                = $::barman::settings::conf_file_path,
   $conf_template                 = 'barman/barman.conf.erb',
   $logrotate_template            = 'barman/logrotate.conf.erb',
   $barman_fqdn                   = $::fqdn,
@@ -427,23 +428,33 @@ class barman (
     require => Package['barman'],
   }
 
-  file { '/etc/barman':
-    ensure  => $ensure_directory,
-    purge   => $purge_unknown_conf,
-    recurse => true,
-    owner   => $user,
-    group   => $group,
-    mode    => '0750',
-    require => Package['barman'],
-  }
+  if $conf_file_path == '/etc/barman/barman.conf' {
+    file { '/etc/barman':
+      ensure  => $ensure_directory,
+      purge   => $purge_unknown_conf,
+      recurse => true,
+      owner   => $user,
+      group   => $group,
+      mode    => '0750',
+      require => Package['barman'],
+    }
 
-  file { '/etc/barman/barman.conf':
-    ensure  => $ensure_file,
-    owner   => $user,
-    group   => $group,
-    mode    => '0640',
-    content => template($conf_template),
-    require => File['/etc/barman'],
+    file { $conf_file_path:
+      ensure  => $ensure_file,
+      owner   => $user,
+      group   => $group,
+      mode    => '0640',
+      content => template($conf_template),
+      require => File['/etc/barman'],
+    }
+  } else {
+    file { $conf_file_path:
+      ensure  => $ensure_file,
+      owner   => $user,
+      group   => $group,
+      mode    => '0640',
+      content => template($conf_template),
+    }
   }
 
   file { $home:

--- a/manifests/settings.pp
+++ b/manifests/settings.pp
@@ -56,6 +56,7 @@ class barman::settings (
   $basebackup_retry_sleep        = false,
   $basebackup_retry_times        = false,
   $check_timeout                 = undef,
+  $conf_file_path                = '/etc/barman/barman.conf',
   $custom_compression_filter     = undef,
   $custom_decompression_filter   = undef,
   $compression                   = 'gzip',

--- a/spec/classes/barman_spec.rb
+++ b/spec/classes/barman_spec.rb
@@ -23,12 +23,34 @@ describe 'barman' do
   it { is_expected.to contain_package('barman').with_tag('postgresql') }
 
   # Creates the configurations
-  it { is_expected.to contain_file('/etc/barman').with_ensure('directory') }
   it { is_expected.to contain_file('/etc/barman.d').with_ensure('directory') }
   it { is_expected.to contain_file('/etc/logrotate.d/barman') }
-  it { is_expected.to contain_file('/etc/barman/barman.conf').with_content(%r{\[barman\]}) }
-  it { is_expected.to contain_file('/etc/barman/barman.conf').with_content(%r{compression = gzip}) }
-  it { is_expected.not_to contain_file('/etc/barman.conf').with_content(%r{_backup_script}) }
+
+  context 'with default conf_file_path' do
+    let(:params) do
+      {
+        conf_file_path: '/etc/barman/barman.conf'
+      }
+    end
+
+    it { is_expected.to contain_file('/etc/barman').with_ensure('directory') }
+    it { is_expected.to contain_file('/etc/barman/barman.conf').with_content(%r{\[barman\]}) }
+    it { is_expected.to contain_file('/etc/barman/barman.conf').with_content(%r{compression = gzip}) }
+    it { is_expected.not_to contain_file('/etc/barman.conf').with_content(%r{_backup_script}) }
+  end
+
+  context 'with conf_file_path override' do
+    let(:params) do
+      {
+        conf_file_path: '/etc/barman.conf'
+      }
+    end
+
+    it { is_expected.not_to contain_file('/etc/barman').with_ensure('directory') }
+    it { is_expected.to contain_file('/etc/barman.conf').with_content(%r{\[barman\]}) }
+    it { is_expected.to contain_file('/etc/barman.conf').with_content(%r{compression = gzip}) }
+    it { is_expected.not_to contain_file('/etc/barman.conf').with_content(%r{_backup_script}) }
+  end
 
   # Creates barman home and launches 'barman check all'
   it { is_expected.to contain_file('/var/lib/barman') }


### PR DESCRIPTION
  For example, on Ubuntu 20.04, apt installs it at /etc/barman.conf