### PR TITLE
Allow dashes Barman::ServerName type

### DIFF
--- a/types/servername.pp
+++ b/types/servername.pp
@@ -1,1 +1,1 @@
-type Barman::ServerName = Pattern[/^[\w]*$/]
+type Barman::ServerName = Pattern[/^[\w-]*$/]


### PR DESCRIPTION
I think allowing `-` in server name is legit.
Also, question regarding `$description` option for the below, reuires to be of type `Barman::ServerName`, which limits what can be put as description. I think description should have be allowed a free text, with spaces, etc ...

https://github.com/deric/puppet-barman/blob/89869bcdb959cd860abab9622728bac7bb373df9/manifests/postgres.pp#L250 and https://github.com/deric/puppet-barman/blob/89869bcdb959cd860abab9622728bac7bb373df9/manifests/server.pp#L201

I can add a change that allows to have more permissive `$description`, lmk.