### PR TITLE
Add barman_lock_directory

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,7 @@
 # [*bandwidth_limit*] - This option allows you to specify a maximum transfer rate
 #                       in kilobytes per second. A value of zero specifies no
 #                       limit (default).
+# [*barman_lock_directory*] - Global option for a directory for lock files.
 # [*check_timeout*] - Maximum execution time, in seconds per server, for a barman
 #                     check command. Set to 0 to disable the timeout. Positive
 #                     integer, default 30.
@@ -239,6 +240,7 @@ class barman (
   Barman::BackupMethod               $backup_method                 = undef,
   Barman::BackupOptions              $backup_options                = undef,
   Optional[Integer]                  $bandwidth_limit               = undef,
+  Optional[String]                   $barman_lock_directory         = undef,
   Optional[Integer]                  $basebackup_retry_sleep        = undef,
   Optional[Integer]                  $basebackup_retry_times        = undef,
   Optional[Integer]                  $check_timeout                 = undef,

--- a/spec/classes/barman_spec.rb
+++ b/spec/classes/barman_spec.rb
@@ -135,6 +135,7 @@ describe 'barman' do
   context 'with different parameters' do
     let(:params) do
       {
+        barman_lock_directory: '/var/run/barman',
         compression: false,
         pre_backup_script: '/bin/false',
         post_backup_script: '/bin/false',
@@ -142,6 +143,7 @@ describe 'barman' do
       }
     end
 
+    it { is_expected.to contain_file('/etc/barman/barman.conf').with_content(%r{barman_lock_directory = /var/run/barman}) }
     it { is_expected.not_to contain_file('/etc/barman/barman.conf').with_content(%r{compression}) }
     it { is_expected.to contain_file('/etc/barman/barman.conf').with_content(%r{pre_backup_script = /bin/false}) }
     it { is_expected.to contain_file('/etc/barman/barman.conf').with_content(%r{post_backup_script = /bin/false}) }

--- a/templates/barman.conf.erb
+++ b/templates/barman.conf.erb
@@ -21,6 +21,9 @@ recovery_options = <%= @recovery_options %>
 <%- if @bandwidth_limit -%>
 bandwidth_limit = <%= @bandwidth_limit %>
 <%- end -%>
+<%- if @barman_lock_directory -%>
+barman_lock_directory = <%= @barman_lock_directory %>
+<%- end -%>
 <%- if @check_timeout -%>
 check_timeout = <%= @check_timeout %>
 <%- end -%>


### PR DESCRIPTION
  If this is set in custom_lines, then for an rsync backup
  the setting will appear in the server level config
  and barman throws a warning in the log that
  "Invalid configuration option "barman_lock_directory" in [myserver]"