### PR TITLE
Add missing parameter 'hba_entry_order'

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -284,6 +284,7 @@ class barman (
   Optional[String]                   $custom_lines                   = undef,
   String                             $archive_cmd_type,
   Optional[Hash]                     $servers                        = undef,
+  Integer                            $hba_entry_order,
 ) {
   # when hash data is in servers, then fire-off barman::server define with that hash data
   if ($servers) {


### PR DESCRIPTION
```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Unknown variable: 'barman::hba_entry_order'. (file: /etc/puppetlabs/code/environments/production/modules/barman/manifests/server.pp, line: 277, column: 24) on node backup
```