### PR TITLE
revert ownerships to Debian defaults

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -353,7 +353,7 @@ class barman (
     ensure  => $ensure_directory,
     purge   => $purge_unknown_conf,
     recurse => true,
-    owner   => $user,
+    owner   => 'root',
     group   => $group,
     mode    => '0750',
     require => Package['barman'],
@@ -364,7 +364,7 @@ class barman (
       ensure  => $ensure_directory,
       purge   => $purge_unknown_conf,
       recurse => true,
-      owner   => $user,
+      owner   => 'root',
       group   => $group,
       mode    => '0750',
       require => Package['barman'],
@@ -372,7 +372,7 @@ class barman (
 
     file { $conf_file_path:
       ensure  => $ensure_file,
-      owner   => $user,
+      owner   => 'root',
       group   => $group,
       mode    => '0640',
       content => template($conf_template),
@@ -381,7 +381,7 @@ class barman (
   } else {
     file { $conf_file_path:
       ensure  => $ensure_file,
-      owner   => $user,
+      owner   => 'root',
       group   => $group,
       mode    => '0640',
       content => template($conf_template),
@@ -423,7 +423,7 @@ class barman (
   file { '/etc/logrotate.d/barman':
     ensure  => $ensure_file,
     owner   => 'root',
-    group   => $group,
+    group   => 0,
     mode    => '0644',
     content => template($logrotate_template),
     require => Package['barman'],

--- a/templates/logrotate.conf.erb
+++ b/templates/logrotate.conf.erb
@@ -5,5 +5,5 @@
     compress
     missingok
     notifempty
-    create 0640 <%= @user %> <%= @group %>
+    create 0640 <%= @user %> adm
 }


### PR DESCRIPTION
In the Debian package configuration, configuration files are owned by root. They are also world-readable (which is not ideal), so we keep the "owned by barman group" permission, but remove the "owned by barman user" permission.

In other words, barman shouldn't be able to modify its own configuration files. Just a precaution.

Closes: #11