### PR TITLE
Support `hour` as possible backup age value

### DIFF
--- a/types/backupage.pp
+++ b/types/backupage.pp
@@ -1,2 +1,2 @@
 # Allowed backup age
-type Barman::BackupAge = Optional[Pattern[/^[1-9][0-9]* (DAY|WEEK|MONTH)S?$/]]
+type Barman::BackupAge = Optional[Pattern[/^[1-9][0-9]* (HOUR|DAY|WEEK|MONTH)S?$/]]


### PR DESCRIPTION
Although the documentation of barman isn't reflecting that, it's supported by [parse_time_interval](https://github.com/EnterpriseDB/barman/blob/16ea407ee6279244a4731cfb5055943520eac1a6/barman/config.py#L198).

There's an [issue](https://github.com/EnterpriseDB/barman/issues/103) to fix this and I'll create a PR to fix the barman documentation.