### PR TITLE
Resolve key facts as root only

### DIFF
--- a/lib/facter/barman_key.rb
+++ b/lib/facter/barman_key.rb
@@ -16,6 +16,9 @@ end
 
 Facter.add('barman_key') do
   confine kernel: 'Linux'
+  confine 'identity' do |identity|
+    identity['uid'] == 0
+  end
   setcode do
     barman_safe_keygen_and_return('barman')
   end
@@ -23,6 +26,9 @@ end
 
 Facter.add('postgres_key') do
   confine kernel: 'Linux'
+  confine 'identity' do |identity|
+    identity['uid'] == 0
+  end
   setcode do
     barman_safe_keygen_and_return('postgres')
   end


### PR DESCRIPTION
In scenarios where facter runs as non root user, this fact may get stuck at a the password prompt triggered by `su - <postgrest/barman>`.

For example the puppet-editor-services language server tries to resolve facts and it's usually run a user.